### PR TITLE
Update readme with cluster information

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,12 @@ RabbitMQ as base cluster node:
     rabbitmq:
       server:
         enabled: true
+        master: openstack1
+        {% if grains['host'] == 'openstack1' %}
+        role: master
+        {% else %}
+        role: slave
+        {% endif %}
         bind:
           address: 0.0.0.0
           port: 5672


### PR DESCRIPTION
If you have more than one node in your system (as document describes) you need to have a master entry pointing out which node to join against. The other nodes should then have role: slave also.